### PR TITLE
Making BnB deterministic

### DIFF
--- a/src/main/scala/one/murch/bitcoin/coinselection/MoneyPotAfterLF.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/MoneyPotAfterLF.scala
@@ -8,7 +8,7 @@ import scala.util.Random
   * Created by murch on 2017-01-19
   */
 object MoneyPotAfterLF extends Scenario(Set(), ListBuffer(), "Imports final UTXO set of LF after running MP, then runs MP") {
-    val rnd = new Random()
+    val rnd = new Random(1)
     var index = 1
     for (line <- Source.fromResource("scenarios/UTXO-post-LF.csv").getLines()) {
         val nextUTXO: Utxo = new Utxo(index, (line).toLong)

--- a/src/main/scala/one/murch/bitcoin/coinselection/StackEfficientTailRecursiveBnB.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/StackEfficientTailRecursiveBnB.scala
@@ -17,6 +17,8 @@ class StackEfficientTailRecursiveBnB(name: String, utxoList: Set[Utxo], feePerKB
     val COST_PER_INPUT = WalletConstants.BYTES_PER_INPUT * feePerKB / 1000
     val extraCostForChange = (WalletConstants.BYTES_PER_OUTPUT + WalletConstants.BYTES_PER_INPUT) * feePerKB / 1000
 
+    var random = new Random(1)
+
     def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Set[Utxo] = {
 
         if (debug == true) {
@@ -29,7 +31,7 @@ class StackEfficientTailRecursiveBnB(name: String, utxoList: Set[Utxo], feePerKB
 
         // Try Branch-and-Bound
         val utxoVec = utxoPool.toArray
-        utxoVecSorted = utxoVec.sortWith(_.value > _.value)
+        utxoVecSorted = utxoVec.sortBy(_.id).sortBy(_.block).sortWith(_.value > _.value)
 
         lookaheadVec = createLookahead(utxoVecSorted, feePerKB)
         selectedUtxo  = new Array[Boolean](utxoVec.size)
@@ -50,7 +52,7 @@ class StackEfficientTailRecursiveBnB(name: String, utxoList: Set[Utxo], feePerKB
 
         //Else select randomly.
         if (selectedCoins == Set()) {
-            var randomizedUtxo = Random.shuffle((utxoPool).toList)
+            var randomizedUtxo = random.shuffle((utxoPool).toList)
 
             while (randomizedUtxo.nonEmpty && selectionTotal(selectedCoins) < target + estimateFeeWithChange(target, selectedCoins, feePerKB) + MIN_CHANGE) {
                 selectedCoins += randomizedUtxo.head


### PR DESCRIPTION
Those little changes make BnB algorithm deterministic.

Note that they are still using random shuffles on failure, but it is shuffled every time the same way.