### PR TITLE
Removing premature return on lookahead

### DIFF
--- a/src/main/scala/one/murch/bitcoin/coinselection/StackEfficientTailRecursiveBnB.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/StackEfficientTailRecursiveBnB.scala
@@ -105,9 +105,6 @@ class StackEfficientTailRecursiveBnB(name: String, utxoList: Set[Utxo], feePerKB
                 depth = lastIncluded + 1
                 while (lastIncluded >= 0 && selectedUtxo(lastIncluded) == false) {
                     lastIncluded -= 1
-                    if (lastIncluded < 0) {
-                        return false
-                    }
                 }
             } else {
                 remainingValueToSelect = remainingValueToSelect - utxoVecSorted(depth).value + COST_PER_INPUT


### PR DESCRIPTION
I think this prematurely ended the BnB algorithm. The fact that we cannot go farther in `depth` and take a shortcut to exclusion branch doesn't mean we should exit if the "newly excluded" is "first" - we still have a lot of branches to explore.