### PR TITLE
Implementing more "failure modes"

### DIFF
--- a/src/main/scala/one/murch/bitcoin/coinselection/Wallet.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/Wallet.scala
@@ -243,3 +243,8 @@ class Wallet(name: String, utxoList: Set[(Int,Long)], debug: Boolean, knapsackLi
     }
 }
 
+object Wallet {
+    def minWalletValue(target: Long): Long = {
+        return target + 2 * WalletConstants.CENT
+    }
+}


### PR DESCRIPTION
"Skip" mode is a bit nonsensical right now; if we "skip", we should also log skipped ones somewhere.

Example: the bitcoinjs/coinselect library sort results first by the percentage of skipped and only THEN by cost.