### PR TITLE
Letting wallets to define failure

### DIFF
--- a/src/main/scala/one/murch/bitcoin/coinselection/AvTargetWallet.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/AvTargetWallet.scala
@@ -4,30 +4,11 @@ class AvTargetWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: B
     var targetsTotal: Long = 0
     var numTargets: Int = 0
 
-    override def spend(target: Long, nLockTime: Int) {
-        if (target > getWalletTotal()) {
-            throw new IllegalArgumentException("one.murch.bitcoin.coinselection.Wallet was requested to spend " + target + " but only contained " + getWalletTotal() + ".");
-        }
-
-        val starttime: Long = System.currentTimeMillis
+    override def adjustMinChange(target: Long) {
         targetsTotal += target
         numTargets += 1
 
         MIN_CHANGE = targetsTotal / numTargets
         println("Current MIN_CHANGE is now: " + MIN_CHANGE)
-
-        var selectedCoins: Set[Utxo] = selectCoins(target, feePerKB, nLockTime)
-
-        //var fee: Long = estimateFee(target, selectedCoins, feePerKB, MIN_CHANGE) ← Core estimates fee in Selection
-        var fee = currentTransactionFee
-
-        var change: Long = selectionTotal(selectedCoins) - target - fee
-
-        val duration = (System.currentTimeMillis) - starttime
-
-        var tx = new Transaction(name, target, change, fee, selectedCoins, nLockTime, duration)
-        executeTransaction(tx)
-        utxoSetSizes += utxoPool.size
-        inTransitRatio += change.toDouble / getWalletTotal()
     }
 }

--- a/src/main/scala/one/murch/bitcoin/coinselection/BlackjackWallet.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/BlackjackWallet.scala
@@ -3,7 +3,7 @@ package one.murch.bitcoin.coinselection
 class BlackjackWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: Boolean) extends AbstractWallet(name, utxoList, feePerKB, debug) {
     val MIN_CHANGE_BEFORE_ADDING_TO_FEE = WalletConstants.DUST_LIMIT
 
-    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Set[Utxo] = {
+    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Option[Set[Utxo]] = {
         if (debug == true) {
             println(name + " is selecting for " + target)
         }
@@ -35,7 +35,11 @@ class BlackjackWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: 
             sortedUtxo = sortedUtxo.tail
         }
 
-        return selectedCoins
+        if (selectionTotal(selectedCoins) < target + estimateFeeWithChange(target, selectedCoins, feePerKB)) {
+            return None
+        }
+
+        return Some(selectedCoins)
     }
 
     def estimateFeeWithChange(target: Long, selectedCoins: Set[Utxo], feePerKB: Long): Long = {

--- a/src/main/scala/one/murch/bitcoin/coinselection/BreadWallet.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/BreadWallet.scala
@@ -3,7 +3,7 @@ package one.murch.bitcoin.coinselection
 class BreadWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: Boolean) extends AbstractWallet(name, utxoList, feePerKB, debug) {
     val MIN_CHANGE_BEFORE_ADDING_TO_FEE = WalletConstants.DUST_LIMIT
 
-    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Set[Utxo] = {
+    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Option[Set[Utxo]] = {
         if (debug == true) {
             println(name + " is selecting for " + target)
         }
@@ -18,7 +18,10 @@ class BreadWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: Bool
             sortedUtxo = sortedUtxo.tail
         }
 
-        return selectedCoins
+        if (selectionTotal(selectedCoins) < target + estimateFeeWithChange(target, selectedCoins, feePerKB)) {
+            return None
+        }
+        return Some(selectedCoins)
     }
 
     def estimateFeeWithChange(target: Long, selectedCoins: Set[Utxo], feePerKB: Long): Long = {

--- a/src/main/scala/one/murch/bitcoin/coinselection/DoubleWallet.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/DoubleWallet.scala
@@ -2,30 +2,12 @@ package one.murch.bitcoin.coinselection
 
 class DoubleWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: Boolean) extends CoreWallet(name, utxoList, feePerKB, debug) {
 
-    override def spend(target: Long, nLockTime: Int) {
-        if (target > getWalletTotal()) {
-            throw new IllegalArgumentException("one.murch.bitcoin.coinselection.Wallet was requested to spend " + target + " but only contained " + getWalletTotal() + ".");
-        }
-
-        val starttime: Long = System.currentTimeMillis
+    override def adjustMinChange(target: Long) {
         if (getWalletTotal() > target * 3) {
             MIN_CHANGE = target
         } else {
             MIN_CHANGE = WalletConstants.CENT
         }
-        var selectedCoins: Set[Utxo] = selectCoins(target, feePerKB, nLockTime)
-
-        //var fee: Long = estimateFee(target, selectedCoins, feePerKB, MIN_CHANGE) ← Core estimates fee in Selection
-        var fee = currentTransactionFee
-
-        var change: Long = selectionTotal(selectedCoins) - target - fee
-
-        val duration = (System.currentTimeMillis) - starttime
-        if(selectedCoins != null && selectedCoins.nonEmpty) {
-            var tx = new Transaction(name, target, change, fee, selectedCoins, nLockTime, duration)
-            executeTransaction(tx)
-            utxoSetSizes += utxoPool.size
-            inTransitRatio += change.toDouble / getWalletTotal()
-        }
     }
+
 }

--- a/src/main/scala/one/murch/bitcoin/coinselection/EfficientBnB.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/EfficientBnB.scala
@@ -10,7 +10,11 @@ class EfficientBnB(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: Boo
     var COST_PER_INPUT = WalletConstants.BYTES_PER_INPUT * feePerKB / 1000
     val extraCostForChange = WalletConstants.BYTES_PER_OUTPUT + WalletConstants.BYTES_PER_INPUT * feePerKB / 1000
 
-    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Set[Utxo] = {
+    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Option[Set[Utxo]] = {
+        // not sure how this wallet behaves with unsufficient funds
+        if (Wallet.minWalletValue(target) >= getWalletTotal()) {
+            return None
+        }
 
         if (debug == true) {
             println(name + " is selecting for " + target + " in block " + nLockTime)
@@ -42,7 +46,7 @@ class EfficientBnB(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: Boo
             }
         }
 
-        return selectedCoins
+        return Some(selectedCoins)
     }
 
     def branchAndBound(maxInputs: Int, depth: Int, selectedCoins: Set[Utxo], effectiveValueSelected: Long, target: Long, utxoVecSorted: Array[Utxo], lookaheadVec: Array[Long], feePerKB: Long): Set[Utxo] = {

--- a/src/main/scala/one/murch/bitcoin/coinselection/LargestFirstWallet.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/LargestFirstWallet.scala
@@ -3,7 +3,7 @@ package one.murch.bitcoin.coinselection
 class LargestFirstWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: Boolean) extends AbstractWallet(name, utxoList, feePerKB, debug) {
     val MIN_CHANGE_BEFORE_ADDING_TO_FEE = WalletConstants.DUST_LIMIT
 
-    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Set[Utxo] = {
+    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Option[Set[Utxo]] = {
         if (debug == true) {
             println(name + " is selecting for " + target)
         }
@@ -17,8 +17,10 @@ class LargestFirstWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, debu
             }
             sortedUtxo = sortedUtxo.tail
         }
-
-        return selectedCoins
+        if (selectionTotal(selectedCoins) < target + estimateFeeWithChange(target, selectedCoins, feePerKB)) {
+            return None
+        }
+        return Some(selectedCoins)
     }
 
     def estimateFeeWithChange(target: Long, selectedCoins: Set[Utxo], feePerKB: Long): Long = {

--- a/src/main/scala/one/murch/bitcoin/coinselection/MyceliumWallet.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/MyceliumWallet.scala
@@ -5,7 +5,12 @@ package one.murch.bitcoin.coinselection
 class MyceliumWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: Boolean) extends AbstractWallet(name, utxoList, feePerKB, debug) {
     val MIN_CHANGE_BEFORE_ADDING_TO_FEE: Long = 5460
 
-    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Set[Utxo] = {
+    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Option[Set[Utxo]] = {
+        // not sure how this wallet behaves with unsufficient funds
+        if (Wallet.minWalletValue(target) >= getWalletTotal()) {
+            return None
+        }
+
         if (debug == true) {
             println(name + " is selecting for " + target)
         }
@@ -35,7 +40,7 @@ class MyceliumWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: B
             selectedUtxoBySize = selectedUtxoBySize.tail
         }
 
-        return selectedCoins
+        return Some(selectedCoins)
     }
 
     def estimateFeeWithChange(target: Long, selectedCoins: Set[Utxo], feePerKB: Long): Long = {

--- a/src/main/scala/one/murch/bitcoin/coinselection/PriorityWallet.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/PriorityWallet.scala
@@ -5,8 +5,7 @@ package one.murch.bitcoin.coinselection
 class PriorityWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: Boolean) extends AbstractWallet(name, utxoList, feePerKB, debug) {
     val MIN_CHANGE_BEFORE_ADDING_TO_FEE = WalletConstants.DUST_LIMIT
 
-    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Set[Utxo] = {
-
+    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Option[Set[Utxo]] = {
         if (debug == true) {
             println(name + " is selecting for " + target + " in block " + nLockTime)
         }
@@ -21,8 +20,10 @@ class PriorityWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: B
             }
             sortedUtxo = sortedUtxo.tail
         }
-
-        return selectedCoins
+        if (selectionTotal(selectedCoins) < target + estimateFeeWithChange(target, selectedCoins, feePerKB)) {
+            return None
+        }
+        return Some(selectedCoins)
     }
 
     def estimateFeeWithChange(target: Long, selectedCoins: Set[Utxo], feePerKB: Long): Long = {

--- a/src/main/scala/one/murch/bitcoin/coinselection/RandomWallet.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/RandomWallet.scala
@@ -7,7 +7,7 @@ class RandomWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: Boo
     val MIN_CHANGE = minChange
     val MIN_CHANGE_BEFORE_ADDING_TO_FEE = WalletConstants.DUST_LIMIT
 
-    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Set[Utxo] = {
+    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Option[Set[Utxo]] = {
 
         if (debug == true) {
             println(name + " is selecting for " + target + " in block " + nLockTime)
@@ -23,8 +23,11 @@ class RandomWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: Boo
             }
             randomizedUtxo = randomizedUtxo.tail
         }
-
-        return selectedCoins
+        if (selectionTotal(selectedCoins) < target + estimateFeeWithChange(target, selectedCoins, feePerKB)) {
+            return None
+        }
+ 
+        return Some(selectedCoins)
     }
 
     def estimateFeeWithChange(target: Long, selectedCoins: Set[Utxo], feePerKB: Long): Long = {

--- a/src/main/scala/one/murch/bitcoin/coinselection/Simulator.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/Simulator.scala
@@ -45,7 +45,6 @@ class Simulator(utxo: Set[Utxo], operations: ListBuffer[Payment], descriptor: St
     val randomWallet8Z = new RandomWallet("RandomWallet8Z", utxo, WalletConstants.FEE_PER_KILOBYTE, false, 100000000)
 */
     var outgoingPaymentsQueue: Queue[Payment] = Queue[Payment]()
-    var currentLowestBalance: Long = 0
 
     //    var wallets: List[AbstractWallet] = List(coreWallet, myceliumWallet, breadWallet, androidWallet, randomWallet, doubleWallet)
     //    var wallets: List[AbstractWallet] = List(randomWallet0Z, randomWallet1Z, randomWallet2Z, randomWallet3Z, randomWallet4Z, randomWallet5Z, randomWallet6Z, randomWallet7Z, randomWallet8Z)
@@ -53,7 +52,6 @@ class Simulator(utxo: Set[Utxo], operations: ListBuffer[Payment], descriptor: St
     var wallets: List[AbstractWallet] = List(setrBnB, lfWallet, bjWallet, sfWallet, yfWallet, ofWallet, randomWallet0Z, randomWallet4Z, randomWallet6Z)
 
     def simulate() {
-        currentLowestBalance = 0
         operations.foreach {
             x =>
                 if (x.value > 0) {
@@ -66,7 +64,6 @@ class Simulator(utxo: Set[Utxo], operations: ListBuffer[Payment], descriptor: St
                     println("Queue first element is " + outgoingPaymentsQueue.front.value)
 
                 }
-                findLowestBalance()
                 println("Current lowest balance is now " + currentLowestBalance)
                 var stop = false;
                 while (false == outgoingPaymentsQueue.isEmpty && !stop) {
@@ -78,7 +75,6 @@ class Simulator(utxo: Set[Utxo], operations: ListBuffer[Payment], descriptor: St
                     if (spendable) {
                         results.foreach(r => r._1.spend(r._2.get, -1 * first.value, first.nLockTime))
                         outgoingPaymentsQueue.dequeue()
-                        findLowestBalance()
                     } else {
                         stop = true;
                     }
@@ -99,12 +95,5 @@ class Simulator(utxo: Set[Utxo], operations: ListBuffer[Payment], descriptor: St
 
         wallets.foreach(_.dumpUtxoSet())
         println("-------------------------------------------------------------------------------")
-    }
-
-    def findLowestBalance() = {
-        currentLowestBalance = Long.MaxValue
-        wallets.foreach {
-            w => currentLowestBalance = Math.min(w.getWalletTotal(), currentLowestBalance)
-        }
     }
 }

--- a/src/main/scala/one/murch/bitcoin/coinselection/SmallestFirstWallet.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/SmallestFirstWallet.scala
@@ -3,10 +3,8 @@ package one.murch.bitcoin.coinselection
 class SmallestFirstWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: Boolean) extends AbstractWallet(name, utxoList, feePerKB, debug) {
     val MIN_CHANGE_BEFORE_ADDING_TO_FEE = WalletConstants.DUST_LIMIT
 
-    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Set[Utxo] = {
-        if (debug == true) {
-            println(name + " is selecting for " + target)
-        }
+    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Option[Set[Utxo]] = {
+
         var selectedCoins: Set[Utxo] = Set()
         var sortedUtxo = utxoPool.toList.sortWith(_.value < _.value)
 
@@ -17,8 +15,11 @@ class SmallestFirstWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, deb
             }
             sortedUtxo = sortedUtxo.tail
         }
-
-        return selectedCoins
+        if (selectionTotal(selectedCoins) < target + estimateFeeWithChange(target, selectedCoins, feePerKB)) {
+            return None
+        }
+ 
+        return Some(selectedCoins)
     }
 
     def estimateFeeWithChange(target: Long, selectedCoins: Set[Utxo], feePerKB: Long): Long = {

--- a/src/main/scala/one/murch/bitcoin/coinselection/StackEfficientTailRecursiveBnB.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/StackEfficientTailRecursiveBnB.scala
@@ -17,7 +17,7 @@ class StackEfficientTailRecursiveBnB(name: String, utxoList: Set[Utxo], feePerKB
     val COST_PER_INPUT = WalletConstants.BYTES_PER_INPUT * feePerKB / 1000
     val extraCostForChange = (WalletConstants.BYTES_PER_OUTPUT + WalletConstants.BYTES_PER_INPUT) * feePerKB / 1000
 
-    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Set[Utxo] = {
+    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Option[Set[Utxo]] = {
 
         if (debug == true) {
             println(name + " is selecting for " + target + " in block " + nLockTime)
@@ -40,6 +40,7 @@ class StackEfficientTailRecursiveBnB(name: String, utxoList: Set[Utxo], feePerKB
 
         branchAndBoundTries = maxTries
         depth = 0
+        lastIncluded = -1
         if(branchAndBound() == true) {
             for(i <- 0 to lastIncluded) {
                 if(selectedUtxo(i) == true) {
@@ -59,9 +60,12 @@ class StackEfficientTailRecursiveBnB(name: String, utxoList: Set[Utxo], feePerKB
                 }
                 randomizedUtxo = randomizedUtxo.tail
             }
+            if (selectionTotal(selectedCoins) < target + estimateFeeWithChange(target, selectedCoins, feePerKB)) {
+                return None
+            }
         }
 
-        return selectedCoins
+        return Some(selectedCoins)
     }
 
     def branchAndBound(): Boolean = {

--- a/src/main/scala/one/murch/bitcoin/coinselection/TailRecursiveBnB.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/TailRecursiveBnB.scala
@@ -13,7 +13,11 @@ class TailRecursiveBnB(name: String, utxoList: Set[Utxo], feePerKB: Long, debug:
     val COST_PER_INPUT = WalletConstants.BYTES_PER_INPUT * feePerKB / 1000
     val extraCostForChange = WalletConstants.BYTES_PER_OUTPUT + WalletConstants.BYTES_PER_INPUT * feePerKB / 1000
 
-    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Set[Utxo] = {
+    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Option[Set[Utxo]] = {
+        // not sure how this wallet behaves with unsufficient funds
+        if (Wallet.minWalletValue(target) >= getWalletTotal()) {
+            return None
+        }
 
         if (debug == true) {
             println(name + " is selecting for " + target + " in block " + nLockTime)
@@ -45,7 +49,7 @@ class TailRecursiveBnB(name: String, utxoList: Set[Utxo], feePerKB: Long, debug:
             }
         }
 
-        return selectedCoins
+        return Some(selectedCoins)
     }
 
     def branchAndBound(depth: Int, remainingValueToSelect: Long): Set[Utxo] = {

--- a/src/main/scala/one/murch/bitcoin/coinselection/Wallet.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/Wallet.scala
@@ -243,3 +243,8 @@ class Wallet(name: String, utxoList: Set[(Int,Long)], debug: Boolean, knapsackLi
     }
 }
 
+object Wallet {
+    def minWalletValue(target: Long): Long = {
+        return target + 2 * WalletConstants.CENT
+    }
+}

--- a/src/main/scala/one/murch/bitcoin/coinselection/YoungestFirstWallet.scala
+++ b/src/main/scala/one/murch/bitcoin/coinselection/YoungestFirstWallet.scala
@@ -3,10 +3,7 @@ package one.murch.bitcoin.coinselection
 class YoungestFirstWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, debug: Boolean) extends AbstractWallet(name, utxoList, feePerKB, debug) {
     val MIN_CHANGE_BEFORE_ADDING_TO_FEE = WalletConstants.DUST_LIMIT
 
-    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Set[Utxo] = {
-        if (debug == true) {
-            println(name + " is selecting for " + target)
-        }
+    def selectCoins(target: Long, feePerKB: Long, nLockTime: Int): Option[Set[Utxo]] = {
         var selectedCoins: Set[Utxo] = Set()
         var sortedUtxo = utxoPool.toList.sortWith(_.id > _.id)
 
@@ -17,8 +14,11 @@ class YoungestFirstWallet(name: String, utxoList: Set[Utxo], feePerKB: Long, deb
             }
             sortedUtxo = sortedUtxo.tail
         }
-
-        return selectedCoins
+        if (selectionTotal(selectedCoins) < target + estimateFeeWithChange(target, selectedCoins, feePerKB)) {
+            return None
+        }
+ 
+        return Some(selectedCoins)
     }
 
     def estimateFeeWithChange(target: Long, selectedCoins: Set[Utxo], feePerKB: Long): Long = {


### PR DESCRIPTION
Instead of guarding insufficient value in simulator, lets wallets themselves define insufficient funds in selectCoins by returning None

I needed to tear apart selectCoins and spend for this.

TODO: measuring time. I was too lazy to do this